### PR TITLE
Add the marker of the latest commit ID for better debugging

### DIFF
--- a/test/e2e-tests-latest-eventing.sh
+++ b/test/e2e-tests-latest-eventing.sh
@@ -62,6 +62,8 @@ function generate_latest_eventing_manifest() {
   # Download the source code of knative eventing
   git clone https://github.com/knative/eventing.git
   cd eventing
+  COMMIT_ID=$(git rev-parse --verify HEAD)
+  echo ">> The latest commit ID of Knative Eventing is ${COMMIT_ID}."
   mkdir -p output
 
   # Generate the manifest


### PR DESCRIPTION
This PR will help us find the commit ID directly, if the periodic prow job fails on a certain commit of eventing.