### PR TITLE
Adding Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+sudo: required
+language: go
+go: 1.13.x
+go_import_path: knative.dev/eventing-operator
+# We need the systemd for the kubeadm and it's default from 16.04+
+dist: bionic
+env:
+  global:
+    - MINIKUBE_WANTUPDATENOTIFICATION=false
+    - MINIKUBE_WANTREPORTERRORPROMPT=false
+    - MINIKUBE_HOME=$HOME
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - KUBECONFIG=$HOME/.kube/config
+    - MINIKUBE_VERSION=v1.6.0
+    - KO_DOCKER_REPO=ko.local
+  jobs:
+    - KUBERNETES_VERSION=v1.17.0
+    - KUBERNETES_VERSION=v1.14.6
+
+install:
+  # ko
+  - go get github.com/google/ko/cmd/ko
+  # kubectl
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  # minikube
+  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+  - mkdir -p $HOME/.kube $HOME/.minikube
+  - touch $KUBECONFIG
+  - sudo minikube start --vm-driver=none --kubernetes-version=${KUBERNETES_VERSION} --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
+  - "sudo chown -R travis: $HOME/.minikube/"
+
+script:
+  - kubectl cluster-info
+  - kubectl version
+  - test/e2e-tests.sh --run-tests


### PR DESCRIPTION
A Travis CI is useful as it is run on infrastructure that users can easily replicate. It utilizes Minikube with `--vm-driver=none`.