### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/eventing/v1alpha1/register_test.go
+++ b/pkg/apis/eventing/v1alpha1/register_test.go
@@ -22,11 +22,11 @@ import (
 )
 
 func TestRegisterHelpers(t *testing.T) {
-	if got, want := Resource(Kind), Kind + "." + GroupName; got.String() != want {
+	if got, want := Resource(Kind), Kind+"."+GroupName; got.String() != want {
 		t.Errorf("Resource(PodAutoscaler) = %v, want %v", got.String(), want)
 	}
 
-	if got, want := SchemeGroupVersion.String(), GroupName + "/" + SchemaVersion; got != want {
+	if got, want := SchemeGroupVersion.String(), GroupName+"/"+SchemaVersion; got != want {
 		t.Errorf("SchemeGroupVersion() = %v, want %v", got, want)
 	}
 


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign k4leung4
/cc k4leung4
