### PR TITLE
Update the year of copyright to 2020 in the template

### DIFF
--- a/hack/boilerplate/boilerplate.go.txt
+++ b/hack/boilerplate/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
As we move into the year of mouse, update the year to 2020 in the template.