### PR TITLE
Add the guidance on upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,7 @@ output of the above `ko publish` command.
 The image should match what's in [config/operator.yaml](config/operator.yaml)
 and the `$VERSION` should match [version.go](version/version.go) and correspond
 to the contents of [config/](config/).
+
+## Upgrade
+
+Please refer to the [upgrade guide](doc/upgrade_guide.md) for a safe upgrade process.

--- a/doc/upgrade_guide.md
+++ b/doc/upgrade_guide.md
@@ -5,7 +5,22 @@ This document describes how to upgrade the eventing-operator to an expected vers
 ## Backup precaution
 
 As an administrator, you are recommended to save the content of the custom resource for eventing-operator
-before upgrading your operator.
+before upgrading your operator. Make sure that you know the name and the namespace of your CR, and use the
+following command to save the CR in a file called `eventing_operator_cr.yaml`:
+
+For the version v0.12.0 or later:
+
+```
+kubectl get KnativeEventing <cr-name> -n <namespace> -o=yaml > eventing_operator_cr.yaml
+```
+
+For the version v0.11.0 or earlier:
+
+```
+kubectl get Eventing <cr-name> -n <namespace> -o=yaml > eventing_operator_cr.yaml
+```
+
+Replace `<cr-name>` with the name of your CR, and `<namespace>` with the namespace.
 
 One version of eventing-operator installs only one specific version of Knative Eventing. With your
 operator successfully upgraded, your Knative Eventing is upgraded as well.
@@ -23,8 +38,8 @@ kubectl apply -f https://github.com/knative/eventing-operator/releases/download/
 
 ## v0.10.0 -> v0.11.0
 
-If your existing operator is at thre version v0.10.0, you cannot directly upgrade it to v0.12.0 or
-later. We only support to upgrade v0.10.0 to v0.11.0. Existing issues about directly upgrading from v0.10.0
+If your existing operator is at the version v0.10.0, you cannot directly upgrade it to v0.12.0 or
+later. We only support upgrade from v0.10.0 to v0.11.0. Existing issues about directly upgrading from v0.10.0
 to v0.12.0 has been report at [Bug 54](https://github.com/knative/eventing-operator/issues/54).
 
 Update the eventing-operator deployment to the version v0.11.0 with the command:

--- a/doc/upgrade_guide.md
+++ b/doc/upgrade_guide.md
@@ -1,0 +1,34 @@
+# Upgrade Guide
+
+This document describes how to upgrade the eventing-operator to an expected version.
+
+## Backup precaution
+
+As an administrator, you are recommended to save the content of the custom resource for eventing-operator
+before upgrading your operator.
+
+One version of eventing-operator installs only one specific version of Knative Eventing. With your
+operator successfully upgraded, your Knative Eventing is upgraded as well.
+
+## v0.11.0 -> v0.12.0
+
+The Kind name of the custom resource has been changed from `Eventing` to `KnativeEventing`. The version
+v0.12.0 is able to recognize both of the CRs.
+
+Update the eventing-operator to the version v0.12.0 with the command:
+
+```
+kubectl apply -f https://github.com/knative/eventing-operator/releases/download/v0.12.0/eventing-operator.yaml
+```
+
+## v0.10.0 -> v0.11.0
+
+If your existing operator is at thre version v0.10.0, you cannot directly upgrade it to v0.12.0 or
+later. We only support to upgrade v0.10.0 to v0.11.0. Existing issues about directly upgrading from v0.10.0
+to v0.12.0 has been report at [Bug 54](https://github.com/knative/eventing-operator/issues/54).
+
+Update the eventing-operator deployment to the version v0.11.0 with the command:
+
+```
+kubectl apply -f https://github.com/knative/eventing-operator/releases/download/v0.11.0/eventing-operator.yaml
+```


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

# Issue to be fixed

Fixes #81

## Proposed Changes

* This PR adds the instruction on how to upgrade eventing-operator from 0.11 and prior.

## Release Note

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
```
