### PR TITLE
Read Kubeconfig from env var if previous methods don't work

### DIFF
--- a/pkg/reconciler/knativeeventing/controller.go
+++ b/pkg/reconciler/knativeeventing/controller.go
@@ -39,7 +39,7 @@ const (
 var (
 	recursive  = flag.Bool("recursive", false, "If filename is a directory, process all manifests recursively")
 	MasterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-	Kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	Kubeconfig = flag.String("kubeconfig", os.Getenv("KUBECONFIG"), "Path to a kubeconfig. Only required if out-of-cluster.")
 )
 
 // NewController initializes the controller and is called by the generated code


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

# Issue to be fixed

Fixes #99 

## Proposed Changes

* Backwards compatible change
* Only use `KUBECONFIG` if the command line argument is empty

## Release Note

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```


Why having this fixes the tests at Operator Hub?
Operator Hub tests work like this:
- Operator is installed on Minikube
- A proxy side car is installed with the operator
- That proxy side car would be the proxy for Kube API and the operator would talk to Kube API through that
- Proxy injects the kubeconfig to the operator container with an env var called `KUBECONFIG`
- Tests then check if the operator reacts to creation of CRs

In our case, operator was doing its work good, but was not using the proxy and thus the tests were unable to detect the operator's actions.