### PR TITLE
Build config consistently as per in serving

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"log"
 
-	"k8s.io/client-go/tools/clientcmd"
 	"knative.dev/eventing-operator/pkg/reconciler/knativeeventing"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/signals"
@@ -28,7 +27,7 @@ import (
 func main() {
 	flag.Parse()
 
-	cfg, err := clientcmd.BuildConfigFromFlags(*knativeeventing.MasterURL, *knativeeventing.Kubeconfig)
+	cfg, err := sharedmain.GetConfig(*knativeeventing.MasterURL, *knativeeventing.Kubeconfig)
 	if err != nil {
 		log.Fatal("Error building kubeconfig", err)
 	}

--- a/pkg/reconciler/knativeeventing/controller.go
+++ b/pkg/reconciler/knativeeventing/controller.go
@@ -16,13 +16,13 @@ package knativeeventing
 import (
 	"context"
 	"flag"
+	"knative.dev/pkg/injection/sharedmain"
 	"os"
 	"path/filepath"
 
 	mf "github.com/manifestival/manifestival"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
 	"knative.dev/eventing-operator/pkg/apis/eventing/v1alpha1"
 	knativeEventinginformer "knative.dev/eventing-operator/pkg/client/injection/informers/eventing/v1alpha1/knativeeventing"
 	rbase "knative.dev/eventing-operator/pkg/reconciler"
@@ -39,7 +39,7 @@ const (
 var (
 	recursive  = flag.Bool("recursive", false, "If filename is a directory, process all manifests recursively")
 	MasterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-	Kubeconfig = flag.String("kubeconfig", os.Getenv("KUBECONFIG"), "Path to a kubeconfig. Only required if out-of-cluster.")
+	Kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 )
 
 // NewController initializes the controller and is called by the generated code
@@ -59,7 +59,7 @@ func NewController(
 
 	koDataDir := os.Getenv("KO_DATA_PATH")
 
-	cfg, err := clientcmd.BuildConfigFromFlags(*MasterURL, *Kubeconfig)
+	cfg, err := sharedmain.GetConfig(*MasterURL, *Kubeconfig)
 	if err != nil {
 		c.Logger.Error(err, "Error building kubeconfig")
 	}


### PR DESCRIPTION
Config building in main and in controller is now done using the same method. This was done in serving PR https://github.com/knative/serving-operator/pull/293

cc @markusthoemmes