### PR TITLE
Keep the sources-controller, since 0.12 still has it

### DIFF
--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -18,7 +18,6 @@ package knativeeventing
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"reflect"
 
 	"go.uber.org/zap"
@@ -116,7 +115,6 @@ func (r *Reconciler) reconcile(ctx context.Context, ke *eventingv1alpha1.Knative
 		r.initStatus,
 		r.install,
 		r.checkDeployments,
-		r.deleteObsoleteResources,
 	}
 
 	manifest, err := r.transform(ke)
@@ -208,51 +206,4 @@ func (r *Reconciler) updateStatus(desired *eventingv1alpha1.KnativeEventing) (*e
 	existing := ke.DeepCopy()
 	existing.Status = desired.Status
 	return r.KnativeEventingClientSet.OperatorV1alpha1().KnativeEventings(desired.Namespace).UpdateStatus(existing)
-}
-
-// Delete obsolete resources from previous versions
-func (r *Reconciler) deleteObsoleteResources(manifest *mf.Manifest, instance *eventingv1alpha1.KnativeEventing) error {
-	resource := &unstructured.Unstructured{}
-	resource.SetNamespace(instance.GetNamespace())
-
-	// Remove old resources from 0.12
-	// https://github.com/knative/eventing-operator/issues/90
-	// sources and controller are merged.
-	// delete removed or renamed resources.
-	resource.SetAPIVersion("v1")
-	resource.SetKind("ServiceAccount")
-	resource.SetName("eventing-source-controller")
-	if err := manifest.Delete(resource, &metav1.DeleteOptions{}); err != nil {
-		return err
-	}
-
-	resource.SetAPIVersion("rbac.authorization.k8s.io/v1")
-	resource.SetKind("ClusterRole")
-	resource.SetName("knative-eventing-source-controller")
-	if err := manifest.Delete(resource, &metav1.DeleteOptions{}); err != nil {
-		return err
-	}
-
-	resource.SetAPIVersion("rbac.authorization.k8s.io/v1")
-	resource.SetKind("ClusterRoleBinding")
-	resource.SetName("eventing-source-controller")
-	if err := manifest.Delete(resource, &metav1.DeleteOptions{}); err != nil {
-		return err
-	}
-
-	resource.SetAPIVersion("rbac.authorization.k8s.io/v1")
-	resource.SetKind("ClusterRoleBinding")
-	resource.SetName("eventing-source-controller-resolver")
-	if err := manifest.Delete(resource, &metav1.DeleteOptions{}); err != nil {
-		return err
-	}
-
-	resource.SetAPIVersion("apps/v1")
-	resource.SetKind("Deployment")
-	resource.SetName("sources-controller")
-	if err := manifest.Delete(resource, &metav1.DeleteOptions{}); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -82,7 +82,7 @@ function knative_setup() {
 }
 
 function install_head() {
-  generate_latest_eventing_manifest
+  generate_latest_eventing_manifest release-0.12
   install_eventing_operator
 }
 
@@ -93,6 +93,11 @@ function generate_latest_eventing_manifest() {
   # Download the source code of knative eventing
   git clone https://github.com/knative/eventing.git
   cd eventing
+  if [[ ! -z "$1" ]]; then
+    local branch=$1
+    git fetch origin ${branch}:${branch}
+    git checkout ${branch}
+  fi
   COMMIT_ID=$(git rev-parse --verify HEAD)
   echo ">> The latest commit ID of Knative Eventing is ${COMMIT_ID}."
   mkdir -p output

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -86,6 +86,8 @@ function install_head() {
   install_eventing_operator
 }
 
+# This function generates the manifest based on a branch for Knative Eventing.
+# Parameter: $1 - branch name. If it is empty, use the default master branch.
 function generate_latest_eventing_manifest() {
   # Go the directory to download the source code of knative eventing
   cd ${KNATIVE_EVENTING_DIR}

--- a/test/upgrade/knativeeventingupgrade_test.go
+++ b/test/upgrade/knativeeventingupgrade_test.go
@@ -56,7 +56,7 @@ func TestKnativeEventingUpgrade(t *testing.T) {
 		resources.AssertKEOperatorCRReadyStatus(t, clients, names)
 		// TODO: We only verify the deployment, but we need to add other resources as well, like ServiceAccount, ClusterRoleBinding, etc.
 		expectedDeployments := []string{"eventing-controller", "eventing-webhook", "imc-controller",
-			"imc-dispatcher", "broker-controller"}
+			"imc-dispatcher", "sources-controller"}
 		knativeEventingVerifyDeployment(t, clients, names, expectedDeployments)
 	})
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

# Issue to be fixed

Fixes #116

## Proposed Changes

* This PR fixes an overlooked error in 0.12, which is that 0.12 still has the deployment named sources-controller.

## Release Note

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
```
