### PR TITLE
Upgrade to latest `test-infra`.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1293,14 +1293,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3d0c703375017dde28d1ee030d7f82ea838ab023841890ead18e91c8c9aded80"
+  digest = "1:8eb056e849457e87707462c777d46705ab24a1030fbc47bc12f47393a981426d"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "7a8eea898f66fc7cd5fec6bb7c0fa2a80eeb702e"
+  revision = "0ccd3908af7dc65a725934029262fe1496e05865"
 
 [[projects]]
   digest = "1:5fdf0517a870044f13def5f9f2dc75eb8cfb88baf7862eaf9884a06152f9391b"

--- a/vendor/knative.dev/test-infra/scripts/release.sh
+++ b/vendor/knative.dev/test-infra/scripts/release.sh
@@ -506,7 +506,7 @@ function main() {
   if [[ -n "${RELEASE_BRANCH}" && -z "${FROM_NIGHTLY_RELEASE}" && "${current_branch}" != "${RELEASE_BRANCH}" ]]; then
     setup_upstream
     setup_branch
-    git checkout upstream/"${RELEASE_BRANCH}" || abort "cannot checkout branch ${RELEASE_BRANCH}"
+    git checkout -b "${RELEASE_BRANCH}" upstream/"${RELEASE_BRANCH}" || abort "cannot checkout branch ${RELEASE_BRANCH}"
     # HACK HACK HACK
     # Rerun the release script from the release branch. Fixes https://github.com/knative/test-infra/issues/1262
     ./hack/release.sh "$@"


### PR DESCRIPTION
Upgrade to latest `test-infra`. Release process was blocked by https://github.com/knative/test-infra/issues/1804
Ran `./hack/update-deps.sh --upgrade && ./hack/update-codegen.sh`


<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

# Issue to be fixed

Fixes #

## Proposed Changes

*
*
*

## Release Note

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
```
