### PR TITLE
Delete (Cluster)Role(Bindings) as a final cleanup step.

### DIFF
--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -74,7 +74,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		var RBAC = mf.Any(mf.ByKind("Role"), mf.ByKind("ClusterRole"), mf.ByKind("RoleBinding"), mf.ByKind("ClusterRoleBinding"))
 
 		if r.eventings.Len() == 0 {
-			if err := r.config.Filter(mf.All(mf.NotCRDs, RBAC)).Delete(); err != nil {
+			if err := r.config.Filter(mf.NotCRDs, mf.None(RBAC)).Delete(); err != nil {
 				return err
 			}
 			// Delete Roles last, as they may be useful for human operators to clean up.

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -71,8 +71,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	if apierrs.IsNotFound(err) {
 		// The resource was deleted
 		r.eventings.Delete(key)
+		var RBAC = mf.Any(mf.ByKind("Role"), mf.ByKind("ClusterRole"), mf.ByKind("RoleBinding"), mf.ByKind("ClusterRoleBinding"))
+
 		if r.eventings.Len() == 0 {
-			r.config.Filter(mf.NotCRDs).Delete()
+			if err := r.config.Filter(mf.All(mf.NotCRDs, RBAC)).Delete(); err != nil {
+				return err
+			}
+			// Delete Roles last, as they may be useful for human operators to clean up.
+			if err := r.config.Filter(RBAC).Delete(); err != nil {
+				return err
+			}
 		}
 		return nil
 


### PR DESCRIPTION
This allows us to take advantage of the permissions granted to cluster admins
when performing cleanup. If the approach in #109
is approved, this will become necessary. Additionally, it makes sense to remove roles as the final
step to allow human Operators to modify any resources they may have permissions on as a result of the Knative installation (that is, we should not remove any access until we are 'almost done' cleaning up).

/lint

## Proposed Changes

*Delete roles and rolebindings as a final cleanup step.

## Release Note

```release-note
Delete roles and rolebindings as a final cleanup step.
```
