### PR TITLE
Install from the manifest in a strict(er) order.

### DIFF
--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -42,6 +42,8 @@ import (
 
 var (
 	platform common.Platforms
+	role mf.Predicate = mf.Any(mf.ByKind("ClusterRole"), mf.ByKind("Role"))
+	rolebinding mf.Predicate = mf.Any(mf.ByKind("ClusterRoleBinding"), mf.ByKind("RoleBinding"))
 )
 
 // Reconciler implements controller.Reconciler for Knativeeventing resources.
@@ -71,7 +73,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	if apierrs.IsNotFound(err) {
 		// The resource was deleted
 		r.eventings.Delete(key)
-		var RBAC = mf.Any(mf.ByKind("Role"), mf.ByKind("ClusterRole"), mf.ByKind("RoleBinding"), mf.ByKind("ClusterRoleBinding"))
+		var RBAC = mf.Any(role, rolebinding)
 
 		if r.eventings.Len() == 0 {
 			if err := r.config.Filter(mf.NoCRDs, mf.None(RBAC)).Delete(); err != nil {
@@ -163,7 +165,18 @@ func (r *Reconciler) transform(instance *eventingv1alpha1.KnativeEventing) (mf.M
 func (r *Reconciler) install(manifest *mf.Manifest, ke *eventingv1alpha1.KnativeEventing) error {
 	r.Logger.Debug("Installing manifest")
 	defer r.updateStatus(ke)
-	if err := manifest.Apply(); err != nil {
+	// The Operator needs a higher level of permissions if it 'bind's non-existent roles.
+	// To avoid this, we strictly order the manifest application as (Cluster)Roles, then
+	// (Cluster)RoleBindings, then the rest of the manifest.
+	if err := manifest.Filter(role).Apply(); err != nil {
+		ke.Status.MarkEventingFailed("Manifest Installation", err.Error())
+		return err
+	}
+	if err := manifest.Filter(rolebinding).Apply(); err != nil {
+		ke.Status.MarkEventingFailed("Manifest Installation", err.Error())
+		return err
+	}
+	if err := manifest.Filter(mf.None(mf.Any(role, rolebinding))).Apply(); err != nil {
 		ke.Status.MarkEventingFailed("Manifest Installation", err.Error())
 		return err
 	}

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -176,7 +176,7 @@ func (r *Reconciler) install(manifest *mf.Manifest, ke *eventingv1alpha1.Knative
 		ke.Status.MarkEventingFailed("Manifest Installation", err.Error())
 		return err
 	}
-	if err := manifest.Filter(mf.None(mf.Any(role, rolebinding))).Apply(); err != nil {
+	if err := manifest.Apply(); err != nil {
 		ke.Status.MarkEventingFailed("Manifest Installation", err.Error())
 		return err
 	}

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -41,8 +41,8 @@ import (
 )
 
 var (
-	platform common.Platforms
-	role mf.Predicate = mf.Any(mf.ByKind("ClusterRole"), mf.ByKind("Role"))
+	platform    common.Platforms
+	role        mf.Predicate = mf.Any(mf.ByKind("ClusterRole"), mf.ByKind("Role"))
 	rolebinding mf.Predicate = mf.Any(mf.ByKind("ClusterRoleBinding"), mf.ByKind("RoleBinding"))
 )
 


### PR DESCRIPTION
This order, Roles -> RoleBindings -> The Rest, prevents the operand from
needing to structure their manifest such that this ordering exists, while
allowing the Operator to use the bootstrapping mechanism described in
https://github.com/knative/eventing-operator/pull/109 to 'escalate' itself
into management of the Knative Eventing installation without a *** clusterrole.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

# Issue to be fixed

Fixes #

## Proposed Changes

* Install roles, then rolebindings, then the remainder of the manifest.

## Release Note

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
```
