### PR TITLE
Override images in env vars

### DIFF
--- a/pkg/reconciler/knativeeventing/common/images.go
+++ b/pkg/reconciler/knativeeventing/common/images.go
@@ -58,6 +58,8 @@ func updateDeployment(instance *eventingv1alpha1.KnativeEventing, u *unstructure
 	log.Debugw("Updating Deployment", "name", u.GetName(), "registry", registry)
 
 	updateDeploymentImage(deployment, &registry, log)
+	updateDeploymentEnvVarImages(deployment, &registry, log)
+
 	deployment.Spec.Template.Spec.ImagePullSecrets = addImagePullSecrets(
 		deployment.Spec.Template.Spec.ImagePullSecrets, &registry, log)
 	err = scheme.Scheme.Convert(deployment, u, nil)
@@ -70,6 +72,19 @@ func updateDeployment(instance *eventingv1alpha1.KnativeEventing, u *unstructure
 
 	log.Debugw("Finished conversion", "name", u.GetName(), "unstructured", u.Object)
 	return nil
+}
+
+func updateDeploymentEnvVarImages(deployment *appsv1.Deployment, registry *eventingv1alpha1.Registry, log *zap.SugaredLogger) {
+	containers := deployment.Spec.Template.Spec.Containers
+	for index := range containers {
+		container := &containers[index]
+		for envIndex := range container.Env {
+			env := &container.Env[envIndex]
+			if newImage, ok := registry.Override[env.Name]; ok {
+				env.Value = newImage
+			}
+		}
+	}
 }
 
 // updateDeploymentImage updates the image of the deployment with a new registry and tag


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

# Issue to be fixed

Fixes #147

## Proposed Changes

* Also override images in env vars

## Release Note

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

To override images in env vars, simply add the env var name as the key in the override map.

Ex:

Deployment
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: broker-controller
  namespace: knative-eventing
spec:
  template:
    spec:
      serviceAccountName: eventing-controller
      containers:
      - name: broker-controller
        terminationMessagePolicy: FallbackToLogsOnError
        image: gcr.io/knative-releases/knative.dev/eventing/cmd/channel_broker@sha256:853e0d194223da4356af7c9a17c79afa0ef96b93fd956d5febb2b1f2be78c717
        env:
        - name: BROKER_INGRESS_IMAGE
          value: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:d080653ce0792a304ba388dcb1e360dc427d8556503e0a2603da26d261ac21e4
```

CR
```
apiVersion: operator.knative.dev/v1alpha1
kind: KnativeEventing
metadata:
...
spec:
  registry:
    override:
      broker-controller: docker.io/my-broker-controller
      BROKER_INGRESS_IMAGE : docker.io/my-broker-ingress
```

Result:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: broker-controller
  namespace: knative-eventing
spec:
  template:
    spec:
      serviceAccountName: eventing-controller
      containers:
      - name: broker-controller
        terminationMessagePolicy: FallbackToLogsOnError
        image: docker.io/my-broker-controller
        env:
        - name: BROKER_INGRESS_IMAGE
          value: docker.io/my-broker-ingress
```
