### PR TITLE
Avoid name conflict by using deployment+delimiter+container as the key

### DIFF
--- a/pkg/reconciler/knativeeventing/common/images.go
+++ b/pkg/reconciler/knativeeventing/common/images.go
@@ -33,6 +33,7 @@ import (
 var (
 	// The string to be replaced by the container name
 	containerNameVariable = "${NAME}"
+	delimiter             = "/"
 )
 
 // DeploymentTransform updates the links of images with customized registries for all deployments
@@ -92,7 +93,7 @@ func updateDeploymentImage(deployment *appsv1.Deployment, registry *eventingv1al
 	containers := deployment.Spec.Template.Spec.Containers
 	for index := range containers {
 		container := &containers[index]
-		newImage := getNewImage(registry, container.Name)
+		newImage := getNewImage(registry, container.Name, deployment.Name)
 		if newImage != "" {
 			updateContainer(container, newImage, log)
 		}
@@ -100,8 +101,11 @@ func updateDeploymentImage(deployment *appsv1.Deployment, registry *eventingv1al
 	log.Debugw("Finished updating images", "name", deployment.GetName(), "containers", deployment.Spec.Template.Spec.Containers)
 }
 
-func getNewImage(registry *eventingv1alpha1.Registry, containerName string) string {
-	overrideImage := registry.Override[containerName]
+func getNewImage(registry *eventingv1alpha1.Registry, containerName, deploymentName string) string {
+	overrideImage := registry.Override[deploymentName+delimiter+containerName]
+	if overrideImage == "" {
+		overrideImage = registry.Override[containerName]
+	}
 	if overrideImage != "" {
 		return overrideImage
 	}

--- a/pkg/reconciler/knativeeventing/common/images_test.go
+++ b/pkg/reconciler/knativeeventing/common/images_test.go
@@ -172,6 +172,96 @@ var updateDeploymentImageTests = []updateDeploymentImageTest{
 			Env:   []corev1.EnvVar{{Name: "SOME_IMAGE", Value: "docker.io/my/overridden-image"}},
 		}},
 	},
+	{
+		name: "OverrideWithDeploymentContainer",
+		containers: []corev1.Container{
+			{
+				Name:  "container1",
+				Image: "gcr.io/cmd/queue:test",
+			},
+			{
+				Name:  "container2",
+				Image: "gcr.io/cmd/queue:test",
+			},
+		},
+		registry: eventingv1alpha1.Registry{
+			Override: map[string]string{
+				"container1": "new-registry.io/test/path/new-container-1:new-tag",
+				"container2": "new-registry.io/test/path/new-container-2:new-tag",
+				"OverrideWithDeploymentContainer/container1": "new-registry.io/test/path/OverrideWithDeploymentContainer/container-1:new-tag",
+				"OverrideWithDeploymentContainer/container2": "new-registry.io/test/path/OverrideWithDeploymentContainer/container-2:new-tag",
+			},
+		},
+		expected: []corev1.Container{
+			{
+				Name:  "container1",
+				Image: "new-registry.io/test/path/OverrideWithDeploymentContainer/container-1:new-tag",
+			},
+			{
+				Name:  "container2",
+				Image: "new-registry.io/test/path/OverrideWithDeploymentContainer/container-2:new-tag",
+			},
+		},
+	},
+	{
+		name: "OverridePartialWithDeploymentContainer",
+		containers: []corev1.Container{
+			{
+				Name:  "container1",
+				Image: "gcr.io/cmd/queue:test",
+			},
+			{
+				Name:  "container2",
+				Image: "gcr.io/cmd/queue:test",
+			},
+		},
+		registry: eventingv1alpha1.Registry{
+			Override: map[string]string{
+				"container1": "new-registry.io/test/path/new-container-1:new-tag",
+				"container2": "new-registry.io/test/path/new-container-2:new-tag",
+				"OverridePartialWithDeploymentContainer/container1": "new-registry.io/test/path/OverridePartialWithDeploymentContainer/container-1:new-tag",
+			},
+		},
+		expected: []corev1.Container{
+			{
+				Name:  "container1",
+				Image: "new-registry.io/test/path/OverridePartialWithDeploymentContainer/container-1:new-tag",
+			},
+			{
+				Name:  "container2",
+				Image: "new-registry.io/test/path/new-container-2:new-tag",
+			},
+		},
+	},
+	{
+		name: "OverrideWithDeploymentName",
+		containers: []corev1.Container{
+			{
+				Name:  "container1",
+				Image: "gcr.io/cmd/queue:test",
+			},
+			{
+				Name:  "container2",
+				Image: "gcr.io/cmd/queue:test",
+			},
+		},
+		registry: eventingv1alpha1.Registry{
+			Override: map[string]string{
+				"OverrideWithDeploymentName/container1": "new-registry.io/test/path/OverrideWithDeploymentName/container-1:new-tag",
+				"OverrideWithDeploymentName/container2": "new-registry.io/test/path/OverrideWithDeploymentName/container-2:new-tag",
+			},
+		},
+		expected: []corev1.Container{
+			{
+				Name:  "container1",
+				Image: "new-registry.io/test/path/OverrideWithDeploymentName/container-1:new-tag",
+			},
+			{
+				Name:  "container2",
+				Image: "new-registry.io/test/path/OverrideWithDeploymentName/container-2:new-tag",
+			},
+		},
+	},
 }
 
 func TestDeploymentTransform(t *testing.T) {
@@ -181,6 +271,7 @@ func TestDeploymentTransform(t *testing.T) {
 		})
 	}
 }
+
 func runDeploymentTransformTest(t *testing.T, tt *updateDeploymentImageTest) {
 	unstructuredDeployment := makeUnstructured(t, makeDeployment(t, tt.name, corev1.PodSpec{Containers: tt.containers}))
 	instance := &eventingv1alpha1.KnativeEventing{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

# Issue to be fixed

Fixes #148

## Proposed Changes

*
*
*

## Release Note

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
```
